### PR TITLE
Fix a typo in tx code

### DIFF
--- a/switch/rf_outlets.yaml
+++ b/switch/rf_outlets.yaml
@@ -75,7 +75,7 @@
     Outlet_304_1:
       protocol: 1
       pulselength: 186
-      code_on: 5330027
+      code_on: 5330227
       code_off: 5330236
       signal_repetitions: 40
       


### PR DESCRIPTION
Thanks for the awesome assistant config example that I have a lot from it.

I just spent quite some time debugging my config when I setup my first Etekcity outlet. It turns out to be a typo. I have a 304 with all exact same codes - so I didn't really test all the code one by one - an oversight here.