### PR TITLE
Update .travis.yml to use Python 3.6

### DIFF
--- a/config/.travis.yml
+++ b/config/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.6"
 install:
   - pip3 install homeassistant
 script:


### PR DESCRIPTION
Home Assistant Release 0.65 dropped support for Python 3.4. Travis CI will not run successfully on new releases until this configuration is changed.