### PR TITLE
get_lights_on()

### DIFF
--- a/config/packages/speech_helper_sensors.yaml.disabled
+++ b/config/packages/speech_helper_sensors.yaml.disabled
@@ -16,13 +16,21 @@ sensor:
       lights_on:
         value_template: >
           {% macro get_lights_on() -%}
-            {%- for group in states.group|groupby('state') -%}
+            {%- for group in states.light|groupby('state') -%}
               {%- for entity in group.list -%}
-                {%- if  entity.state == 'on'
-                    and entity.name.split(' ')[1]|lower == 'lights'
-                    and entity.name.split(' ')[0]|lower != 'interior'
-                    and entity.name.split(' ')[0]|lower != 'all'
-                     -%}
+                {%- if entity.state == 'on'
+                    and entity.entity_id != 'light.dummy'
+                    and entity.entity_id != 'light.garage_entry_light'
+                    and entity.entity_id != 'light.hue'
+                    and entity.entity_id != 'light.living_room'
+                    and entity.entity_id != 'light.kitchen_undercabinet'
+                    and entity.entity_id != 'light.porch_light'
+                    and entity.entity_id != 'light.shoe_closet_light'
+                    and not ('gateway_light' in entity.entity_id)
+                    and not ('hub'           in entity.entity_id)
+                    and not (entity.entity_id).endswith('_led')
+                    and not (entity.entity_id).endswith('nightlight')
+                    and not (entity.entity_id).startswith('light.lamplinc') -%}
                   {{ entity.entity_id }}{{ ' ' }}
                 {%- endif -%}
               {%- endfor -%}


### PR DESCRIPTION
Here is my current version. I ignore lights that start with, end with, or contain certain strings. I now store this list in the "variable" custom component. 

Source: https://github.com/brianhanifin/Home-Assistant-Config/blob/master/scripts/lights/lights_on_update.yaml