### PR TITLE
Replace illegal chars in entity names

### DIFF
--- a/config/scene/tv_time.yaml
+++ b/config/scene/tv_time.yaml
@@ -1,20 +1,20 @@
 - name: TV Time
   entities:
-       light.M1_front_left:
+       light.m1_front_left:
            state: off
            transition: 10
-       light.M1_front_right:
+       light.m1_front_right:
            state: off
            transition: 10
-       light.M1_slider:
+       light.m1_slider:
            state: off
            transition: 10
-       light.M1_back_right:
+       light.m1_back_right:
            state: on
            transition: 10
            color_name: 'Gold'
            brightness: 30
-       light.M1_back_left:
+       light.m1_back_left:
            state: on
            transition: 40
            color_name: 'Gold'


### PR DESCRIPTION
Upper case not valid for entity names.
Should fix the build error