### PR TITLE
fix failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 install:
   - pip3 install homeassistant
   - pip3 install colorlog
+  - pip3 install python-dateutil
 
 script:
   - hass -c config/ --script check_config --info all


### PR DESCRIPTION
should build with Travis.
Installs python-dateutil for august component
I believe that the august component is working in HA even though it's failing on travis?