### PR TITLE
Fix Docker dashboard card population after group migration

### DIFF
--- a/config/dashboards/infrastructure/partials/docker_containers_sections.yaml
+++ b/config/dashboards/infrastructure/partials/docker_containers_sections.yaml
@@ -194,7 +194,7 @@
       card_param: cards
       filter:
         include:
-        - group: switch.docker_monitored_containers
+        - entity_id: "/^switch\\..*_container(_2)?$/"
           options:
             type: custom:button-card
             template: bearstone_infra_container_row

--- a/config/dashboards/infrastructure/partials/home_sections.yaml
+++ b/config/dashboards/infrastructure/partials/home_sections.yaml
@@ -449,7 +449,7 @@
         card_param: cards
         filter:
           include:
-          - group: switch.docker_monitored_containers
+          - entity_id: "/^switch\\..*_container(_2)?$/"
             options:
               type: custom:button-card
               template: bearstone_infra_container_row

--- a/config/dashboards/infrastructure/templates/button_card_templates.yaml
+++ b/config/dashboards/infrastructure/templates/button_card_templates.yaml
@@ -614,13 +614,15 @@ bearstone_infra_container_row:
           }
           const switchEntity = key ? `switch.${key}_container` : '';
           const switchEntityAlt = key ? `switch.${key}_container_2` : '';
-          const monitored = states['switch.docker_monitored_containers']?.attributes?.entity_id || [];
+          const monitored = states['switch.docker_monitored_containers']?.attributes?.entity_id;
           const restartCandidates = key ? [
             `button.${key}_restart_container`,
             `button.${key}_restart_container_2`,
           ] : [];
           const hasRestart = restartCandidates.some((candidate) => states[candidate]);
-          const isMonitored = monitored.includes(switchEntity) || monitored.includes(switchEntityAlt);
+          const isMonitored = Array.isArray(monitored)
+            ? monitored.includes(switchEntity) || monitored.includes(switchEntityAlt)
+            : (ent.startsWith('switch.') && (ent.endsWith('_container') || ent.endsWith('_container_2')));
           return (hasRestart && isMonitored) ? 'block' : 'none';
         ]]]
 


### PR DESCRIPTION
## Summary
Fixes a dashboard regression introduced after the Docker monitored group migration.

## Problem
The Docker dashboard container rows were empty because `auto-entities` was configured with:
- `group: switch.docker_monitored_containers`

That expansion path did not populate cards reliably in this setup.

## Changes
- Updated Docker container auto-entities filters to include container switches directly by entity-id pattern:
  - `"/^switch\\..*_container(_2)?$/"`
- Added a defensive fallback in `bearstone_infra_container_row` so restart-control visibility still works when `switch.docker_monitored_containers` has no `entity_id` attribute.

## Validation
- `pwsh -NoProfile -File tools/validate_dashboards.ps1` ✅
- `pwsh -NoProfile -File tools/ha_ui_smoke.ps1` ✅
- Captured Playwright screenshots:
  - `/root/.codex/screenshots/infra-root-after-fix.png`
  - `/root/.codex/screenshots/infra-docker-after-fix.png`

Follow-up to: #1639