### PR TITLE
[codex] Add bedroom wake alarm helpers

### DIFF
--- a/config/packages/README.md
+++ b/config/packages/README.md
@@ -39,6 +39,7 @@ Live collection of plug-and-play Home Assistant packages. Each YAML file in this
 | Package | What it unlocks | Notable entities / services |
 | --- | --- | --- |
 | [alarm.yaml](alarm.yaml) | NodeMCU-powered perimeter monitoring with arm/disarm helpers and rich notifications. | `binary_sensor.mcu*_gpio*`, `group.family`, notify + siren scripts |
+| [alexa_media_player.yaml](alexa_media_player.yaml) | Alexa Media helper sensors including stable bedroom wake-alarm wrappers for Carlo and Stacey plus a combined next-wake view. | `sensor.last_alexa`, `sensor.bedroom_next_wake_alarm`, `sensor.bedroom_next_wake_alarm_source`, `binary_sensor.bedroom_next_wake_alarm_active` |
 | [garadget.yaml](garadget.yaml) | MQTT-based control + status for both garage doors, feeding entry/exit lighting routines. | `cover.large_garage_door`, `cover.small_garage_door`, `sensor.garadget_reflection` |
 | [august.yaml](august.yaml) | Front-door August smart lock with Alexa Show camera pop-up when unlocked. | `lock.front_door`, media_player actions for front doorbell camera |
 | [holiday.yaml](holiday.yaml) | REST-driven US holiday + flag sensors that color scenes and exterior lighting. | `sensor.holiday`, `sensor.flag`, JSON feed at `config/json_data/holidays.json` |

--- a/config/packages/alexa_media_player.yaml
+++ b/config/packages/alexa_media_player.yaml
@@ -6,6 +6,9 @@
 # Alexa Media Player - Sensors and notifications via Alexa Media integration.
 #  Track Alexa media state and expose routine/command triggers.
 # -------------------------------------------------------------------
+# Related Issue: 858
+# Notes: Wrapper wake-alarm sensors normalize Alexa Media `next_alarm` IDs.
+# Notes: Current wake-alarm scope is limited to Carlo Bedroom + Stacey Bedroom.
 ######################################################################
 
 template:
@@ -14,3 +17,132 @@ template:
         unique_id: last_alexa
         state: >
           {{ states.media_player | selectattr('attributes.last_called','eq',True) | map(attribute='entity_id') | first | default('none') }}
+      - name: "Carlo Bedroom Wake Alarm"
+        unique_id: carlo_bedroom_wake_alarm
+        device_class: timestamp
+        icon: mdi:alarm
+        state: >
+          {% set invalid = ['unknown', 'unavailable', 'none', ''] %}
+          {% set primary = states('sensor.carlo_bedroom_next_alarm') %}
+          {% set secondary = states('sensor.carlo_bedroom_next_alarm_2') %}
+          {% set value = primary if primary not in invalid else secondary %}
+          {% set ts = as_timestamp(value, none) %}
+          {{ ts | timestamp_local if ts is not none else none }}
+      - name: "Stacey Bedroom Wake Alarm"
+        unique_id: stacey_bedroom_wake_alarm
+        device_class: timestamp
+        icon: mdi:alarm
+        state: >
+          {% set invalid = ['unknown', 'unavailable', 'none', ''] %}
+          {% set primary = states('sensor.stacey_bedroom_next_alarm') %}
+          {% set secondary = states('sensor.stacey_bedroom_next_alarm_2') %}
+          {% set value = primary if primary not in invalid else secondary %}
+          {% set ts = as_timestamp(value, none) %}
+          {{ ts | timestamp_local if ts is not none else none }}
+      - name: "Bedroom Next Wake Alarm"
+        unique_id: bedroom_next_wake_alarm
+        device_class: timestamp
+        icon: mdi:alarm
+        state: >
+          {% set now_ts = as_timestamp(now()) %}
+          {% set max_ts = now_ts + 172800 %}
+          {% set carlo_raw = states('sensor.carlo_bedroom_next_alarm') %}
+          {% set carlo_fallback = states('sensor.carlo_bedroom_next_alarm_2') %}
+          {% set stacey_raw = states('sensor.stacey_bedroom_next_alarm') %}
+          {% set stacey_fallback = states('sensor.stacey_bedroom_next_alarm_2') %}
+          {% set carlo_ts = as_timestamp(carlo_raw, none) if carlo_raw not in ['unknown', 'unavailable', 'none', ''] else as_timestamp(carlo_fallback, none) %}
+          {% set stacey_ts = as_timestamp(stacey_raw, none) if stacey_raw not in ['unknown', 'unavailable', 'none', ''] else as_timestamp(stacey_fallback, none) %}
+          {% set carlo_ok = carlo_ts is not none and carlo_ts >= (now_ts - 900) and carlo_ts <= max_ts %}
+          {% set stacey_ok = stacey_ts is not none and stacey_ts >= (now_ts - 900) and stacey_ts <= max_ts %}
+          {% if carlo_ok and stacey_ok %}
+            {{ [carlo_ts, stacey_ts] | min | timestamp_local }}
+          {% elif carlo_ok %}
+            {{ carlo_ts | timestamp_local }}
+          {% elif stacey_ok %}
+            {{ stacey_ts | timestamp_local }}
+          {% else %}
+            {{ none }}
+          {% endif %}
+      - name: "Bedroom Next Wake Alarm Source"
+        unique_id: bedroom_next_wake_alarm_source
+        icon: mdi:account-voice
+        state: >
+          {% set now_ts = as_timestamp(now()) %}
+          {% set max_ts = now_ts + 172800 %}
+          {% set carlo_raw = states('sensor.carlo_bedroom_next_alarm') %}
+          {% set carlo_fallback = states('sensor.carlo_bedroom_next_alarm_2') %}
+          {% set stacey_raw = states('sensor.stacey_bedroom_next_alarm') %}
+          {% set stacey_fallback = states('sensor.stacey_bedroom_next_alarm_2') %}
+          {% set carlo_ts = as_timestamp(carlo_raw, none) if carlo_raw not in ['unknown', 'unavailable', 'none', ''] else as_timestamp(carlo_fallback, none) %}
+          {% set stacey_ts = as_timestamp(stacey_raw, none) if stacey_raw not in ['unknown', 'unavailable', 'none', ''] else as_timestamp(stacey_fallback, none) %}
+          {% set carlo_ok = carlo_ts is not none and carlo_ts >= (now_ts - 900) and carlo_ts <= max_ts %}
+          {% set stacey_ok = stacey_ts is not none and stacey_ts >= (now_ts - 900) and stacey_ts <= max_ts %}
+          {% if carlo_ok and stacey_ok %}
+            {{ 'Carlo Bedroom' if carlo_ts <= stacey_ts else 'Stacey Bedroom' }}
+          {% elif carlo_ok %}
+            Carlo Bedroom
+          {% elif stacey_ok %}
+            Stacey Bedroom
+          {% else %}
+            none
+          {% endif %}
+      - name: "Bedroom Next Wake Alarm Minutes"
+        unique_id: bedroom_next_wake_alarm_minutes
+        unit_of_measurement: min
+        state_class: measurement
+        icon: mdi:timer-outline
+        state: >
+          {% set now_ts = as_timestamp(now()) %}
+          {% set max_ts = now_ts + 172800 %}
+          {% set carlo_raw = states('sensor.carlo_bedroom_next_alarm') %}
+          {% set carlo_fallback = states('sensor.carlo_bedroom_next_alarm_2') %}
+          {% set stacey_raw = states('sensor.stacey_bedroom_next_alarm') %}
+          {% set stacey_fallback = states('sensor.stacey_bedroom_next_alarm_2') %}
+          {% set carlo_ts = as_timestamp(carlo_raw, none) if carlo_raw not in ['unknown', 'unavailable', 'none', ''] else as_timestamp(carlo_fallback, none) %}
+          {% set stacey_ts = as_timestamp(stacey_raw, none) if stacey_raw not in ['unknown', 'unavailable', 'none', ''] else as_timestamp(stacey_fallback, none) %}
+          {% set carlo_ok = carlo_ts is not none and carlo_ts >= (now_ts - 900) and carlo_ts <= max_ts %}
+          {% set stacey_ok = stacey_ts is not none and stacey_ts >= (now_ts - 900) and stacey_ts <= max_ts %}
+          {% if carlo_ok and stacey_ok %}
+            {{ ((([carlo_ts, stacey_ts] | min) - now_ts) / 60) | round(0) }}
+          {% elif carlo_ok %}
+            {{ ((carlo_ts - now_ts) / 60) | round(0) }}
+          {% elif stacey_ok %}
+            {{ ((stacey_ts - now_ts) / 60) | round(0) }}
+          {% else %}
+            {{ none }}
+          {% endif %}
+  - binary_sensor:
+      - name: "Carlo Bedroom Wake Alarm Armed"
+        unique_id: carlo_bedroom_wake_alarm_armed
+        icon: mdi:alarm-check
+        state: >
+          {% set now_ts = as_timestamp(now()) %}
+          {% set max_ts = now_ts + 172800 %}
+          {% set primary = states('sensor.carlo_bedroom_next_alarm') %}
+          {% set secondary = states('sensor.carlo_bedroom_next_alarm_2') %}
+          {% set value = primary if primary not in ['unknown', 'unavailable', 'none', ''] else secondary %}
+          {% set ts = as_timestamp(value, none) %}
+          {{ ts is not none and ts >= now_ts and ts <= max_ts }}
+      - name: "Stacey Bedroom Wake Alarm Armed"
+        unique_id: stacey_bedroom_wake_alarm_armed
+        icon: mdi:alarm-check
+        state: >
+          {% set now_ts = as_timestamp(now()) %}
+          {% set max_ts = now_ts + 172800 %}
+          {% set primary = states('sensor.stacey_bedroom_next_alarm') %}
+          {% set secondary = states('sensor.stacey_bedroom_next_alarm_2') %}
+          {% set value = primary if primary not in ['unknown', 'unavailable', 'none', ''] else secondary %}
+          {% set ts = as_timestamp(value, none) %}
+          {{ ts is not none and ts >= now_ts and ts <= max_ts }}
+      - name: "Bedroom Next Wake Alarm Armed"
+        unique_id: bedroom_next_wake_alarm_armed
+        icon: mdi:alarm-check
+        state: >
+          {{ states('sensor.bedroom_next_wake_alarm') not in ['unknown', 'unavailable', 'none', ''] }}
+      - name: "Bedroom Next Wake Alarm Active"
+        unique_id: bedroom_next_wake_alarm_active
+        icon: mdi:alarm-light
+        state: >
+          {% set next_alarm = as_timestamp(states('sensor.bedroom_next_wake_alarm'), none) %}
+          {% set now_ts = as_timestamp(now()) %}
+          {{ next_alarm is not none and now_ts >= next_alarm and now_ts <= (next_alarm + 900) }}

--- a/config/recorder.yaml
+++ b/config/recorder.yaml
@@ -6,7 +6,7 @@
 # Recorder Configuration - database retention and exclusions
 #  Stores HA history while purging noise and controlling DB size.
 # -------------------------------------------------------------------
-# Notes: Keeps 180 days (1/2 year); excludes vcloudinfo pings, noisy connectivity telemetry, and other high-churn entities; MariaDB via recorder_db_url.
+# Notes: Keeps 180 days (1/2 year); excludes vcloudinfo pings, noisy connectivity telemetry, countdown-style alarm helpers, and other high-churn entities; MariaDB via recorder_db_url.
 ######################################################################
 db_url: !secret recorder_db_url
 purge_keep_days: 180
@@ -56,6 +56,7 @@ exclude:
     - sensor.*_wi_fi_signal
     - sensor.*_wifi_signal
     - sensor.*_wifi_signal_strength
+    - sensor.*_wake_alarm_minutes
     - sensor.*_temperature_state
     - sensor.*_humidity_state
     - sensor.*_last_seen*


### PR DESCRIPTION
## What changed
- added wrapper timestamp and binary sensors in `alexa_media_player.yaml` for Carlo Bedroom, Stacey Bedroom, and a combined bedroom wake-alarm view
- documented the new Alexa helper package surface in `config/packages/README.md`
- excluded the derived wake-alarm countdown sensor from recorder history to avoid churn

## Why
Alexa Media `next_alarm` entity IDs can drift between the primary and fallback bedroom alarm sensors. These wrappers normalize that behavior and expose a stable bedroom-level alarm view for downstream automations and dashboards.

## Impact
- downstream HA logic can target stable bedroom wake-alarm entities instead of raw Alexa Media alarm sensors
- recorder noise stays down by skipping the minute countdown helper

## Validation
- `tools/ha_check_config.ps1` returned `Configuration valid`