### PR TITLE
[codex] Harden OneNote cleanup prompt

### DIFF
--- a/config/packages/onenote_indexer.yaml
+++ b/config/packages/onenote_indexer.yaml
@@ -138,7 +138,11 @@ automation:
           diagnostics: "scheduled_time=03:15:00"
           request: >-
             Run OneNote duplicate cleanup and apply deletions.
-            Include delete reconciliation, then send a brief conversational morning summary.
+            Start with any dependency check needed before cleanup or delete reconciliation.
+            If cleanup does not finish cleanly or index health is not confirmed, report back with:
+            Headline: Cleanup did not finish cleanly; index health is not confirmed.
+            Action: Retry cleanup after dependency check.
+            Otherwise include delete reconciliation, then send a brief conversational morning summary.
             Tell me whether cleanup finished and whether anything actually changed.
             Only include detailed counts or backend metrics if pages were removed, something failed, or you need my attention.
 


### PR DESCRIPTION
## What changed
- updated the scheduled OneNote cleanup request so it starts with a dependency check before cleanup and delete reconciliation
- added an explicit fallback response when cleanup does not finish cleanly or index health is not confirmed

## Why
The previous prompt assumed cleanup would succeed and left less room for the agent to stop early when prerequisites or index health were questionable. This version makes the failure path explicit and keeps the morning summary from overstating success.

## Impact
- failed or partial cleanup runs should now report a clear retry action instead of sounding complete
- successful runs still proceed through delete reconciliation and the brief morning summary

## Validation
- `tools/ha_check_config.ps1` returned `Configuration valid`